### PR TITLE
restore previous openhpc patch that defaults to a sleeptime of 0 for

### DIFF
--- a/provision/initramfs/capabilities/transport-http/wwgetfiles
+++ b/provision/initramfs/capabilities/transport-http/wwgetfiles
@@ -29,7 +29,7 @@ else
     exit
 fi
 
-WWGETFILES_INTERVAL=${WWGETFILES_INTERVAL:-180}
+WWGETFILES_INTERVAL=${WWGETFILES_INTERVAL:-0}
 
 if [ -n "$WWGETFILES_INTERVAL" -a $WWGETFILES_INTERVAL -gt 0 ];then
     if [ -n "$RANDOM" -a ! -f "/init" ]; then


### PR DESCRIPTION
Can we get this patch back in? It re-enables interactive usage of `wwgetfiles`. 